### PR TITLE
Disable source maps since they do not work

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedParameters": true,
     "preserveConstEnums": true,
     "removeComments": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strictNullChecks": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
The emitted files atm include paths like:
`"sources":["../../src/AutoUI/index.tsx"]`
which webpack can't load (and prints a lot
warnings about) since we do not include the
src files in the package.

Change-type: patch