### PR TITLE
Remove FocusSearch on server side pagination

### DIFF
--- a/src/AutoUI/index.tsx
+++ b/src/AutoUI/index.tsx
@@ -358,6 +358,8 @@ export const AutoUI = <T extends AutoUIBaseResource<T>>({
 		});
 	};
 
+	console.log('diooo');
+
 	return (
 		<Flex flex={1} flexDirection="column" {...boxProps}>
 			<Spinner
@@ -409,17 +411,20 @@ export const AutoUI = <T extends AutoUIBaseResource<T>>({
 													autouiContext={autouiContext}
 													changeFilters={$setFilters}
 													changeViews={setViews}
-													onSearch={(term) => (
-														<FocusSearch
-															searchTerm={term}
-															filtered={filtered}
-															selected={selected ?? []}
-															setSelected={$setSelected}
-															autouiContext={autouiContext}
-															model={model}
-															hasUpdateActions={hasUpdateActions}
-														/>
-													)}
+													// TODO: add a way to handle the focus search on server side pagination as well
+													{...(!pagination?.serverSide && {
+														onSearch: (term) => (
+															<FocusSearch
+																searchTerm={term}
+																filtered={filtered}
+																selected={selected ?? []}
+																setSelected={$setSelected}
+																autouiContext={autouiContext}
+																model={model}
+																hasUpdateActions={hasUpdateActions}
+															/>
+														),
+													})}
 												/>
 											</Box>
 											<LensSelection


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Andrea Rosci <andrear@balena.io>


We are disabling the focusSearch in a server side pagination until we find a better solution. 

The idea for now would be to pass an onSearchChange sharing a generated $filter from the model (can use the converter) event where we can emit a query like:

```
	for( const propertyKey in model.schema.properties ) {
		const value = model.schema.properties[propertyKey];
		if(value.type !== 'string') {
			return;
		}

		Object.assign($filter, {[key]: {$contains: UserInputString}})
	}

```

```
	sdk.get({
		resource: 'some_resource',
		options: {
			$filter: generatedFilter
		}
	})
```