### PR TITLE
Add x-header-doc schema property to add additional info on column hea…

### DIFF
--- a/src/AutoUI/index.tsx
+++ b/src/AutoUI/index.tsx
@@ -34,6 +34,7 @@ import {
 	setToLocalStorage,
 	getSelected,
 	getSortingFunction,
+	getHeaderDocumentation,
 } from './utils';
 import { FocusSearch } from './Filters/FocusSearch';
 import { CustomWidget } from './CustomWidget';
@@ -547,7 +548,14 @@ export {
 export type AutoUIEntityPropertyDefinition<T> = Required<
 	Pick<
 		TableColumn<T>,
-		'title' | 'label' | 'field' | 'key' | 'selected' | 'sortable' | 'render'
+		| 'title'
+		| 'label'
+		| 'field'
+		| 'key'
+		| 'selected'
+		| 'sortable'
+		| 'render'
+		| 'headerDocumentation'
 	>
 > & { type: string; priority: string };
 
@@ -622,6 +630,7 @@ const getColumnsFromSchema = <T extends AutoUIBaseResource<T>>({
 			}
 			const definedPriorities = priorities ?? ({} as Priorities<T>);
 			const refScheme = sieve.getPropertyScheme(val);
+			const headerDocumentation = getHeaderDocumentation(val);
 			const priority = definedPriorities.primary.find(
 				(prioritizedKey) => prioritizedKey === key,
 			)
@@ -642,6 +651,7 @@ const getColumnsFromSchema = <T extends AutoUIBaseResource<T>>({
 				priority,
 				type: 'predefined',
 				refScheme: refScheme?.[0],
+				headerDocumentation,
 				sortable: customSort?.[key] ?? getSortingFunction(key, val),
 				render: (fieldVal: string, entry: T) => {
 					const calculatedField = autoUIAdaptRefScheme(fieldVal, val);

--- a/src/AutoUI/utils.ts
+++ b/src/AutoUI/utils.ts
@@ -212,3 +212,17 @@ export const onClickOutOrEsc = (
 	document.addEventListener('mousedown', handleClickOutside);
 	document.addEventListener('keydown', handleEsc);
 };
+
+export const getHeaderDocumentation = (
+	schemaValue: JSONSchema | NonNullable<JSONSchema['properties']>[number],
+) => {
+	if (typeof schemaValue === 'boolean' || !schemaValue.description) {
+		return null;
+	}
+	try {
+		const json = JSON.parse(schemaValue.description!);
+		return json['x-header-doc'];
+	} catch (err) {
+		return null;
+	}
+};


### PR DESCRIPTION
Add x-header-doc schema property to add additional info on column headers

See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/x-header-docs.20positioning/near/348710839

Change-type: minor