### PR TITLE
Fix typo for empty table views descriptions

### DIFF
--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -21,7 +21,7 @@ const translationMap = {
 	'no_data.no_resource_data': "You don't have any {{resource}} yet.",
 	'no_data.no_resource_data_title': 'This is where all your {{resource}} live.',
 	'no_data.no_resource_data_description':
-		"This is a bit empty now, let's go ahead and add one",
+		"This is a bit empty right now, let's go ahead and add one",
 	'questions.how_about_adding_one': 'How about adding one?',
 	'resource.item_plural': 'Items',
 	'success.resource_added_successfully': '{{name}} added successfully',


### PR DESCRIPTION
Fix typo for empty table views descriptions

Change-type: patch