### PR TITLE
Migrate Spinner from rendition to MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@balena/ui-shared-components": "^5.1.0",
+    "@balena/ui-shared-components": "^5.2.0",
     "json-e": "^4.4.3",
     "lodash": "^4.17.21",
     "qs": "^6.10.3",

--- a/src/AutoUI/Actions/Create.tsx
+++ b/src/AutoUI/Actions/Create.tsx
@@ -8,9 +8,8 @@ import {
 import { ActionData } from '../schemaOps';
 import { getCreateDisabledReason } from '../utils';
 import { useTranslation } from '../../hooks/useTranslation';
-import { Spinner } from 'rendition';
 import { ActionContent, LOADING_DISABLED_REASON } from './ActionContent';
-import { Material, Tooltip } from '@balena/ui-shared-components';
+import { Material, Tooltip, Spinner } from '@balena/ui-shared-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMagic } from '@fortawesome/free-solid-svg-icons/faMagic';
 
@@ -91,7 +90,7 @@ export const Create = <T extends AutoUIBaseResource<T>>({
 						<Box display="flex" justifyContent="space-between">
 							{action.title}
 							<Spinner
-								ml={2}
+								sx={{ ml: 2 }}
 								show={disabledReason === LOADING_DISABLED_REASON}
 							/>
 						</Box>

--- a/src/AutoUI/Actions/Update.tsx
+++ b/src/AutoUI/Actions/Update.tsx
@@ -8,13 +8,14 @@ import {
 import { ActionData } from '../schemaOps';
 import { autoUIGetDisabledReason } from '../utils';
 import { useTranslation } from '../../hooks/useTranslation';
-import { CheckedState, Spinner } from 'rendition';
+import { CheckedState } from 'rendition';
 import { ActionContent, LOADING_DISABLED_REASON } from './ActionContent';
 import {
 	DropDownButton,
 	DropDownButtonProps,
 	Material,
 	Tooltip,
+	Spinner,
 } from '@balena/ui-shared-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPenToSquare } from '@fortawesome/free-solid-svg-icons/faPenToSquare';
@@ -187,7 +188,7 @@ export const Update = <T extends AutoUIBaseResource<T>>({
 							<Box display="flex" justifyContent="space-between">
 								{action.title}
 								<Spinner
-									ml={2}
+									sx={{ ml: 2 }}
 									show={disabledReason === LOADING_DISABLED_REASON}
 								/>
 							</Box>

--- a/src/AutoUI/index.tsx
+++ b/src/AutoUI/index.tsx
@@ -41,7 +41,6 @@ import {
 	Dictionary,
 	FiltersView,
 	Format,
-	Spinner,
 	TableColumn,
 	SchemaSieve as sieve,
 	Link,
@@ -62,7 +61,7 @@ import {
 import { CollectionLensRendererProps } from './Lenses/types';
 import pickBy from 'lodash/pickBy';
 import { NoRecordsFoundView } from './NoRecordsFoundView';
-import { Material } from '@balena/ui-shared-components';
+import { Material, Spinner } from '@balena/ui-shared-components';
 const { Box, styled } = Material;
 
 const DEFAULT_ITEMS_PER_PAGE = 50;
@@ -411,15 +410,20 @@ export const AutoUI = <T extends AutoUIBaseResource<T>>({
 	return (
 		<Box display="flex" flex={1} flexDirection="column" {...boxProps}>
 			<Spinner
-				flex={1}
 				label={
 					isBusyMessage ??
 					t('loading.resource', {
 						resource: t(`resource.${model.resource}_other`).toLowerCase(),
 					})
 				}
-				show={data == null || loading || !!isBusyMessage}
-				{...(data == null ? { width: '100%', height: '100%' } : undefined)}
+				show={
+					(Array.isArray(data)
+						? data?.length
+							? false
+							: loading
+						: data == null || loading) || !!isBusyMessage
+				}
+				sx={{ height: '100%' }}
 			>
 				<Box display="flex" height="100%" flexDirection="column">
 					{


### PR DESCRIPTION
Migrate Spinner from rendition to MUI

Depends-on: https://github.com/balena-io-modules/ui-shared-components/pull/81
Connects-to: https://github.com/balena-io/balena-ui/pull/6516
Change-type: patch