### PR TITLE
Migrate Checkboxes from rendition to MUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@balena/ui-shared-components": "^5.0.8",
+    "@balena/ui-shared-components": "^5.1.0",
     "json-e": "^4.4.3",
     "lodash": "^4.17.21",
     "qs": "^6.10.3",

--- a/src/AutoUI/Filters/FocusSearch.tsx
+++ b/src/AutoUI/Filters/FocusSearch.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import reject from 'lodash/reject';
 import { AutoUIModel } from '..';
-import { Checkbox, Txt, SchemaSieve as sieve } from 'rendition';
+import { Txt, SchemaSieve as sieve } from 'rendition';
 import { AutoUIContext } from '../schemaOps';
 import { useHistory } from '../../hooks/useHistory';
-import { stopEvent } from '../utils';
 import { Material, designTokens } from '@balena/ui-shared-components';
 
-const { Box, styled } = Material;
+const { Box, styled, Checkbox } = Material;
 
 const Focus = styled(Box)(() => ({
 	flexBasis: '100%',
@@ -96,8 +95,7 @@ export const FocusSearch = <T extends { id: number; [key: string]: any }>({
 			<FocusContent>
 				{filteredFittingSearchTerms.map((entity) => (
 					<FocusItem
-						px={1}
-						py={2}
+						p={1}
 						key={entity[rowKey]}
 						onClick={(e) => {
 							e.preventDefault();
@@ -112,40 +110,27 @@ export const FocusSearch = <T extends { id: number; [key: string]: any }>({
 						}}
 						hasGetBaseUrl={!!autouiContext.getBaseUrl}
 					>
-						<Box display="flex" flexDirection="row">
+						<Box display="flex" flexDirection="row" alignItems="center">
 							{hasUpdateActions && (
-								<Box
-									display="flex"
-									flexDirection="column"
-									ml={1}
-									mr={3}
-									alignItems="center"
-								>
-									<Checkbox
-										onChange={() => {
-											const isChecked = !!selected.find(
-												(s) => s[rowKey] === entity[rowKey],
-											);
-											const checkedItems = !isChecked
-												? selected.concat(entity)
-												: (reject(selected, {
-														[rowKey]: entity[rowKey],
-												  }) as unknown as Array<typeof entity>);
-											setSelected(checkedItems);
-										}}
-										checked={
-											!!selected.find((s) => s[rowKey] === entity[rowKey])
-										}
-										onClick={stopEvent}
-									/>
-								</Box>
+								<Checkbox
+									onChange={() => {
+										const isChecked = !!selected.find(
+											(s) => s[rowKey] === entity[rowKey],
+										);
+										const checkedItems = !isChecked
+											? selected.concat(entity)
+											: (reject(selected, {
+													[rowKey]: entity[rowKey],
+											  }) as unknown as Array<typeof entity>);
+										setSelected(checkedItems);
+									}}
+									checked={!!selected.find((s) => s[rowKey] === entity[rowKey])}
+									onClick={(e) => {
+										e.stopPropagation();
+									}}
+								/>
 							)}
-							<Box
-								display="flex"
-								flexDirection="column"
-								alignItems="center"
-								ml={!hasUpdateActions ? 1 : undefined}
-							>
+							<Box display="flex" flexDirection="column" alignItems="center">
 								<Txt>{getEntityValue(entity)}</Txt>
 							</Box>
 						</Box>


### PR DESCRIPTION
Migrate Checkboxes from rendition to MUI

Connects-to: https://github.com/balena-io/balena-ui/pull/6520
Change-type: patch