### PR TITLE
Fix build failing

### DIFF
--- a/src/components/Filters/SchemaSieve.ts
+++ b/src/components/Filters/SchemaSieve.ts
@@ -10,7 +10,7 @@ import pickBy from 'lodash/pickBy';
 import { enqueueSnackbar } from '@balena/ui-shared-components';
 
 const ajv = new Ajv();
-ajvKeywords(ajv, ['regexp']);
+ajvKeywords(ajv as any, ['regexp']);
 addFormats(ajv);
 
 export interface FilterDescription {


### PR DESCRIPTION
Builds are failing because of a bump in ajv. I looked at @JSReds's PR for the fix: https://github.com/balena-io-modules/autoui/pull/97/files#diff-279625c0d4ab69194547046a42899104d269756a05e915a61450de52d2017b2fR13

Change-type: patch